### PR TITLE
Replacing redirect with pushContext

### DIFF
--- a/CRM/Booking/Form/Booking/Info.php
+++ b/CRM/Booking/Form/Booking/Info.php
@@ -83,7 +83,7 @@ class CRM_Booking_Form_Booking_Info extends CRM_Booking_Form_Booking_Base {
         'name' => ts('<< Back'),
       ),
       array(
-        'type' => 'submit',
+        'type' => 'next',
         'name' => ts('Complete and Save'),
       ),
     );
@@ -373,7 +373,8 @@ class CRM_Booking_Form_Booking_Info extends CRM_Booking_Form_Booking_Base {
          "reset=1&id=$bookingID&cid=$cid&action=view"
       );
       CRM_Core_Session::setStatus($booking['title'], ts('Saved'), 'success');
-      CRM_Utils_System::redirect( $url);
+      $session->pushUserContext($url);
+
     }
     catch (CiviCRM_API3_Exception $e) {
       $transaction->rollback();


### PR DESCRIPTION
I'm working on a extension that tries to customise CiviBooking without altering the base extension.
Here is a little improvement that allow to change the redirection after the submit using a subclass of  CRM_Booking_Form_Booking_Info

pushUserContext should be preferred to a manual redirect.