### PR TITLE
PCBK-250: Fixed close actions for the modal

### DIFF
--- a/js/booking/add-sub-resource/app.js
+++ b/js/booking/add-sub-resource/app.js
@@ -18,7 +18,7 @@ var ModalRegion = Backbone.Marionette.Region.extend({
       title: view.title,
       minWidth: '700',
       close: function() {
-        cj( this ).dialog( "destroy" );
+        cj( this ).dialog( "close" );
       }
     });
   },


### PR DESCRIPTION
Destroy command for dialog does not remove the modal completely. In our case we really need to hide the element because we are not recreating it again. So changed from **destroy** to **close**.