### PR TITLE
Fixed for config set edit issue

### DIFF
--- a/CRM/Admin/Form/ResourceConfigSet.php
+++ b/CRM/Admin/Form/ResourceConfigSet.php
@@ -68,7 +68,7 @@ class CRM_Admin_Form_ResourceConfigSet extends CRM_Admin_Form {
     $resourceDao->is_active = TRUE;
     
     if($resourceDao->count() > 0){
-      $statusCheckbox->setAttribute('disabled', 'disabled');
+      $statusCheckbox->freeze(array('is_active'));
     }
 
 


### PR DESCRIPTION
Editing Resource Configuration Set makes it inactive.

After checking code and some debug found that In CRM/Admin/Form/ResourceConfigSet.php we are  allowing state changes and delete only when there are no enabled resources and we are using "disabled" attribute , so in post process we not able to get values of Is active fields and we are setting those as "0".
