### PR TITLE
HC-61: Fix Configuration Selection Combo on Basket Add Form

### DIFF
--- a/templates/CRM/Booking/Form/SelectResource.js
+++ b/templates/CRM/Booking/Form/SelectResource.js
@@ -167,7 +167,7 @@ cj(function ($) {
                             },
                             'api.option_value.get': {
                                 value: '$value.unit_id',
-                                sequental: 1,
+                                sequential: 1,
                                 option_group_id: '$value.api.option_group.get.value'
                             }
                         }

--- a/templates/CRM/Booking/Form/SelectResource.js
+++ b/templates/CRM/Booking/Form/SelectResource.js
@@ -160,13 +160,14 @@ cj(function ($) {
                     'api.resource_config_set.get': {
                         id: '$value.set_id',
                         'api.resource_config_option.get': {
-                            set_id: '$value.set_id',
+                            set_id: '$value.id',
                             is_active: 1,
                             'api.option_group.get': {
                                 name: 'booking_size_unit',
                             },
                             'api.option_value.get': {
                                 value: '$value.unit_id',
+                                sequental: 1,
                                 option_group_id: '$value.api.option_group.get.value'
                             }
                         }

--- a/templates/CRM/Booking/tpl/select-option.tpl
+++ b/templates/CRM/Booking/tpl/select-option.tpl
@@ -2,7 +2,7 @@
   {literal}
   <option value=""><%= first_option %></option>
   <% _.each(options, function (option){ %>
-   <option  <%= option.selected %> data-maxsize="<%= option.max_size %>" data-price="<%= option.price %>" value="<%= option.id %>"><%= option.label %> - {/literal}{$currencySymbols}{literal}<%= option.price %> / <%= option.label %></option>
+   <option  <%= option.selected %> data-maxsize="<%= option.max_size %>" data-price="<%= option.price %>" value="<%= option.id %>"><%= option.label %> - {/literal}{$currencySymbols}{literal}<%= option.price %> / <%= option['api.option_value.get'].values[0].label %></option>
   <% }); %>
   {/literal}
 </script>


### PR DESCRIPTION
## Overview
Configuration drop down was displaying all the configuration set options, not only the corresponding ones! The booking extension can be used fine though, but the drop down should only show the related config sets only.

On the other hand, when you open the Configuration drop down, it displays the "[configuration set option label] - [price] - [configuration set option label]", however, it should be "[configuration set option label] - [price] - [unit].

## Before
Selection combo was showing all configuration options, no matter what resource was selected. This was happening because the configuration set's ID was not being used to filter the result. On the other hand, the option's label was being used instead of the unit's label where units should appear.

## After
Fixed the API call so config set's ID was properly chained to options. Also, changed the template for config options so unit label is used instead of config option label.