### PR TITLE
HC-61: Fix Loading of Resource Configuration Options

### DIFF
--- a/js/booking/add-sub-resource/view.js
+++ b/js/booking/add-sub-resource/view.js
@@ -399,6 +399,7 @@ CRM.BookingApp.module('AddSubResource', function(AddSubResource, BookingApp, Bac
                   },
                   'api.option_value.get':{
                     value: '$value.unit_id',
+                    sequential: 1,
                     option_group_id: '$value.api.option_group.get.id'
                   }
                 }


### PR DESCRIPTION
## Overview
Fixing the load of resource configuration options on form to schedule a time-boxed resource seems to have broken the form to add unlimited resources, causing configuration options failure to load.

## Before
Form to add unlimited resources got broken when the template used to generate the options was changed to include units, as the API call to obtain options did not use the sequential flag. This is important because the unit label is being accessed by looking for the first item in the units array (ie. item with index 0).

## After
Fixed by includig the sequential flag as true in the API call.