### PR TITLE
PCBK-287: Fix Issue Running Upgrader

### DIFF
--- a/CRM/Booking/Upgrader.php
+++ b/CRM/Booking/Upgrader.php
@@ -186,6 +186,8 @@ class CRM_Booking_Upgrader extends CRM_Booking_Upgrader_Base {
     }
 
     CRM_Core_BAO_Navigation::resetNavigation();
+    
+    return TRUE;
   }
 
   /**


### PR DESCRIPTION
## Overview
Errors where found when upgrading the extension for a client.

## Before
An exception was being thrown when running upgrader 1101.

## After
Upgraders should return a boolean value, true on success, false on failure. No value was returned on upgrader 1101, causing the issue. Fixed by returning TRUE.