### PR TITLE
Update hook_civicrm_tabset for forward-compat with 5.57

### DIFF
--- a/booking.php
+++ b/booking.php
@@ -11,9 +11,9 @@ require_once 'booking.civix.php';
  * Display a booking tab listing booking belong to that contact.
  */
 function booking_civicrm_tabset($tabsetName, &$tabs, $context) {
-  if ($tabsetName === 'civicrm/contact/view' && !empty($context['contact_id'])) {
+  if ($tabsetName === 'civicrm/contact/view') {
     $cid = $context['contact_id'];
-    $count = CRM_Booking_BAO_Booking::getBookingContactCount($cid); //TODO Count number of booking and show on the tab
+    $count = CRM_Booking_BAO_Booking::getBookingContactCount($cid);
     $tab = [
       'id' => 'booking',
       'count' => $count,


### PR DESCRIPTION
This makes the hook both forward and backward compatible with current and future versions of core and the ContactLayout extension.