### PR TITLE
Remove reference to protected $_id because it is already declared in Base Parent Class

### DIFF
--- a/CRM/Admin/Form/AdhocChargesItem.php
+++ b/CRM/Admin/Form/AdhocChargesItem.php
@@ -38,7 +38,6 @@ use CRM_Booking_ExtensionUtil as E;
  *
  */
 class CRM_Admin_Form_AdhocChargesItem extends CRM_Admin_Form {
-  protected $_id = NULL;
 
   function preProcess() {
     parent::preProcess();

--- a/CRM/Admin/Form/Resource.php
+++ b/CRM/Admin/Form/Resource.php
@@ -38,7 +38,6 @@ use CRM_Booking_ExtensionUtil as E;
  *
  */
 class CRM_Admin_Form_Resource extends CRM_Admin_Form {
-  protected $_id = NULL;
 
   function preProcess() {
     parent::preProcess();

--- a/CRM/Admin/Form/ResourceConfigOption.php
+++ b/CRM/Admin/Form/ResourceConfigOption.php
@@ -38,7 +38,6 @@ use CRM_Booking_ExtensionUtil as E;
  *
  */
 class CRM_Admin_Form_ResourceConfigOption extends CRM_Admin_Form {
-  protected $_id = NULL;
   protected $_sid = NULL;
 
   function preProcess() {

--- a/CRM/Admin/Form/ResourceConfigSet.php
+++ b/CRM/Admin/Form/ResourceConfigSet.php
@@ -38,7 +38,6 @@ use CRM_Booking_ExtensionUtil as E;
  *
  */
 class CRM_Admin_Form_ResourceConfigSet extends CRM_Admin_Form {
-  protected $_id = NULL;
 
   function preProcess() {
     parent::preProcess();

--- a/CRM/Booking/Form/Booking/Base.php
+++ b/CRM/Booking/Form/Booking/Base.php
@@ -40,8 +40,6 @@ use CRM_Booking_ExtensionUtil as E;
  */
 abstract class CRM_Booking_Form_Booking_Base extends CRM_Core_Form {
 
-  protected $_id;
-
   protected $_cid;
 
   protected $_values;

--- a/CRM/Booking/Form/SelectResource.php
+++ b/CRM/Booking/Form/SelectResource.php
@@ -14,9 +14,7 @@ class CRM_Booking_Form_SelectResource extends CRM_Core_Form {
    *
    * @var integer
    */
-  //protected $_id;
-
-  
+ 
   private $configOptions;
   
   /**


### PR DESCRIPTION
The CiviCRM Base class, "CRM_Admin_Form extends CRM_Core_Form" declares a public $_id variable and redeclaring it as protected causes a fatal error. This pull request removes protected $_id from 6 forms although the reference to protected $_id was already commented out in CRM/Booking/Form/SelectResource.php